### PR TITLE
TEST: allow selection of tests at command line

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,19 +7,25 @@ else
     const Test = BaseTestNext
 end
 
-tests = ["2by2.jl",
-         "singular.jl",
-         "finite_difference.jl",
-         "minpack.jl",
-         "iface.jl",
-         "already_converged.jl",
-         "autodiff.jl",
-         "josephy.jl",
-         "difficult_mcp.jl",
-         "sparse.jl",
-         "throws.jl",
-         "f_g_counts.jl",
-         "no_linesearch.jl"]
+add_jl(x) = endswith(x, ".jl") ? x : x*".jl"
+
+if length(ARGS) > 0
+    tests = map(add_jl, ARGS)
+else
+    tests = ["2by2.jl",
+             "singular.jl",
+             "finite_difference.jl",
+             "minpack.jl",
+             "iface.jl",
+             "already_converged.jl",
+             "autodiff.jl",
+             "josephy.jl",
+             "difficult_mcp.jl",
+             "sparse.jl",
+             "throws.jl",
+             "f_g_counts.jl",
+             "no_linesearch.jl"]
+end
 
 println("Running tests:")
 


### PR DESCRIPTION
This is fairly innocent. It just allows you to specify which tests to run at the command line.

Default behavior of `julia runtests.jl` is unaffected.

But, you can no do `julia runtests.jl minpack` to run just the tests in test/minpack.jl  or `julia runtets.jl minpack sparse` to run the tests in test/minpack.jl test/sparse.jl