### PR TITLE
Bugs

### DIFF
--- a/src/newton.jl
+++ b/src/newton.jl
@@ -76,7 +76,7 @@ function newton_{T}(df::AbstractDifferentiableMultivariateFunction,
             df.f!(xlin, fvec)
             f_calls += 1
         end
-        return(dot(fvec, fvec) / 2)
+        dot(fvec, fvec) / 2
     end
 
     # The line search algorithm will want to first compute ∇fo(xₖ).
@@ -97,7 +97,7 @@ function newton_{T}(df::AbstractDifferentiableMultivariateFunction,
     end
     function fgo!(xlin::Vector, storage::Vector)
         go!(xlin, storage)
-        return(dot(fvec, fvec) / 2)
+        dot(fvec, fvec) / 2
     end
 
     dfo = OnceDifferentiable(fo, go!, fgo!)
@@ -116,7 +116,7 @@ function newton_{T}(df::AbstractDifferentiableMultivariateFunction,
             p = fjac\fvec
             scale!(p, -1)
         catch e
-            if isa(e, Base.LinAlg.LAPACKException)
+            if isa(e, Base.LinAlg.LAPACKException) || isa(e, Base.LinAlg.SingularException)
                 # Modify the search direction if the jacobian is singular
                 # FIXME: better selection for lambda, see Nocedal & Wright p. 289
                 fjac2 = fjac'*fjac

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,18 +1,13 @@
-function wdot{T}(w::Vector{T}, x::Vector{T}, y::Vector{T})
+function wdot{T}(wx::AbstractVector{T}, x::AbstractVector{T},
+                 wy::AbstractVector{T}, y::AbstractVector{T})
     out = zero(T)
     @inbounds @simd for i in 1:length(x)
-        out += w[i] * x[i] * y[i]
+        out += wx[i]*x[i] * wy[i]*y[i]
     end
     return out
 end
 
-function wnorm{T}(w::AbstractVector{T}, x::AbstractVector{T})
-    out = zero(T)
-    @inbounds @simd for i in eachindex(w)
-        out += (w[i] * x[i])^2
-    end
-    sqrt(out)
-end
+wnorm{T}(w::AbstractVector{T}, x::AbstractVector{T}) = sqrt(wdot(w, x, w, x))
 
 function assess_convergence(x::Vector,
                             x_previous::Vector,


### PR DESCRIPTION
I've  just been going through and cleaning up a few bugs.

So far I have:

- In newton if the Jacobian is singular we were only catching `LAPACKException`, but should have also been looking out for `SingularException`.
- In trust region there were a couple things wrong:
    - the weighted norm function wasn't correct - it should have been applying the weights to both input vectors, but was only applying it once
    - The equation for `tau` didn't match Nocedal and Wright or what this package had just before this commit: 21fba867ef1c578f68971b79df4c2f7fba1d5c14. It is entirely possible that what is there right now is also correct, but I couldn't immediately see it so I just implemented the condition we had before that commit
    - I couldn't tell what was going on, so I added some comments
