### PR TITLE
Basic implementation of Anderson acceleration

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ If  `g!` conserves the sparsity structure of `gx`, `gx` will always have the sam
 
 # Fine tunings
 
-Two algorithms are currently available. The choice between the two is achieved
+Three algorithms are currently available. The choice between these is achieved
 by setting the optional `method` argument of `nlsolve`. The default algorithm
 is the trust region method.
 
@@ -270,6 +270,23 @@ the [`LineSearches`](https://github.com/anriseth/LineSearches.jl) package.
 By default, no linesearch is performed.
 **Note:** it is assumed that a passed linesearch function will at least update the solution
 vector and evaluate the function at the new point.
+
+## Anderson acceleration
+
+Also known as DIIS or Pulay mixing, this method is based on the
+acceleration of the fixed-point iteration `xn+1 = xn + β f(xn)`, where
+by default `β=1`. It does not use Jacobian information or linesearch,
+but has a history whose size is controlled by the `m` parameter: `m=0`
+(the default) corresponds to the simple fixed-point iteration above,
+and higher values use a larger history size to accelerate the
+iterations. Higher values of `m` usually increase the speed of
+convergence, but increase the storage and computation requirements and
+might lead to instabilities. This method is useful to accelerate a
+fixed-point iteration `xn+1 = g(xn)` (in which case use this solver
+with `f(x) = g(x) - x`).
+
+Reference: H. Walker, P. Ni, Anderson acceleration for fixed-point
+iterations, SIAM Journal on Numerical Analysis, 2011
 
 ## Common options
 
@@ -368,6 +385,7 @@ julia> fvec
 * Broyden updating of Jacobian in trust-region
 * Homotopy methods
 * [LMMCP algorithm by C. Kanzow](http://www.mathematik.uni-wuerzburg.de/~kanzow/)
+* QR updating of the least-squares problem in the Anderson acceleration solver
 
 # Related Packages
 

--- a/src/NLsolve.jl
+++ b/src/NLsolve.jl
@@ -42,6 +42,7 @@ include("mcp_func_defs.jl")
 include("utils.jl")
 include("newton.jl")
 include("trust_region.jl")
+include("anderson.jl")
 include("autodiff.jl")
 include("mcp.jl")
 

--- a/src/anderson.jl
+++ b/src/anderson.jl
@@ -61,8 +61,7 @@
         new_x = copy(gs[:,1])
         if m_eff > 0
             mat[:, 1:m_eff] .= (gs[:,2:m_eff+1] .- xs[:,2:m_eff+1]) .- (gs[:,1] .- xs[:,1])
-            A_ldiv_B!(alphas[1:m_eff], mat[:,1:m_eff], xs[:,1] .- gs[:,1])
-            alphas[m_eff+1:end] .= zero(T)
+            alphas[1:m_eff] .= mat[:,1:m_eff] \ (xs[:,1] .- gs[:,1])
             for i = 1:m_eff
                 new_x .+= alphas[i].*(gs[:,i+1] .- gs[:,1])
             end

--- a/src/anderson.jl
+++ b/src/anderson.jl
@@ -1,3 +1,5 @@
+# Notations from Walker & Ni, "Anderson acceleration for fixed-point iterations", SINUM 2011
+# Attempts to accelerate the iteration xn+1 = xn + β f(x)
 
 function anderson_{T}(df::AbstractDifferentiableMultivariateFunction,
                       x0::Vector{T},

--- a/src/anderson.jl
+++ b/src/anderson.jl
@@ -90,7 +90,7 @@ function anderson{T}(df::AbstractDifferentiableMultivariateFunction,
                      store_trace::Bool,
                      show_trace::Bool,
                      extended_trace::Bool,
-                     hist_size::Integer,
+                     m::Integer,
                      beta::Real)
-    anderson_(df, initial_x, convert(T, xtol), convert(T, ftol), iterations, store_trace, show_trace, extended_trace, hist_size, beta)
+    anderson_(df, initial_x, convert(T, xtol), convert(T, ftol), iterations, store_trace, show_trace, extended_trace, m, beta)
 end

--- a/src/anderson.jl
+++ b/src/anderson.jl
@@ -1,0 +1,89 @@
+
+function anderson_{T}(df::AbstractDifferentiableMultivariateFunction,
+                      x0::Vector{T},
+                      xtol::T,
+                      ftol::T,
+                      iterations::Integer,
+                      store_trace::Bool,
+                      show_trace::Bool,
+                      extended_trace::Bool,
+                      m::Integer,
+                      β :: Real)
+
+    f_calls = 0
+    N = length(x0)
+    xs = zeros(T,N,m+1) #ring buffer storing the iterates, from newest to oldest
+    gs = zeros(T,N,m+1) #ring buffer storing the g of the iterates, from newest to oldest
+    fx = similar(x0) # temp variable to store f!
+    xs[:,1] = x0
+    errs = zeros(iterations)
+    n = 1
+    tr = SolverTrace()
+    tracing = store_trace || show_trace || extended_trace
+    old_x = xs[:,1]
+
+    for n = 1:iterations
+        # fixed-point iteration
+        df.f!(xs[:,1], fx)
+        f_calls += 1
+        gs[:,1] .= xs[:,1] .+ β.*fx
+        x_converged, f_converged, converged = assess_convergence(gs[:,1], old_x, fx, xtol, ftol)
+
+        # FIXME: How should this flag be set?
+        mayterminate = false
+        
+        if tracing
+            dt = Dict()
+            if extended_trace
+                dt["x"] = copy(xs[:,1])
+                dt["f(x)"] = copy(fx)
+            end
+            update!(tr,
+                    n,
+                    maximum(abs,fx),
+                    n > 1 ? sqeuclidean(xs[:,1],old_x) : convert(T,NaN),
+                    dt,
+                    store_trace,
+                    show_trace)            
+        end
+        
+        if converged
+            break
+        end
+
+        #update of new_x
+        m_eff = min(n-1,m)
+        new_x = gs[:,1]
+        if m_eff > 0
+            mat = (gs[:,2:m_eff+1] .- xs[:,2:m_eff+1]) .- (gs[:,1] - xs[:,1])
+            alphas = -mat \ (gs[:,1] .- xs[:,1])
+            for i = 1:m_eff
+                new_x .+= alphas[i].*(gs[:,i+1] .- gs[:,1])
+            end
+        end
+
+        xs = circshift(xs,(0,1)) # no in-place circshift, unfortunately...
+        gs = circshift(gs,(0,1))
+        old_x = m > 1 ? xs[:,2] : copy(xs[:,1])
+        xs[:,1] = new_x
+    end
+
+    return SolverResults("Anderson m=$m β=$β",
+                         # returning gs[:,1] would be slightly better here, but the fnorm is not guaranteed
+                         x0, xs[:,1], maximum(abs,fx),
+                         n, x_converged, xtol, f_converged, ftol, tr,
+                         f_calls, 0)
+end
+
+function anderson{T}(df::AbstractDifferentiableMultivariateFunction,
+                     initial_x::Vector{T},
+                     xtol::Real,
+                     ftol::Real,
+                     iterations::Integer,
+                     store_trace::Bool,
+                     show_trace::Bool,
+                     extended_trace::Bool,
+                     hist_size::Integer,
+                     beta::Real)
+    anderson_(df, initial_x, convert(T, xtol), convert(T, ftol), iterations, store_trace, show_trace, extended_trace, hist_size, beta)
+end

--- a/src/anderson.jl
+++ b/src/anderson.jl
@@ -23,6 +23,7 @@ function anderson_{T}(df::AbstractDifferentiableMultivariateFunction,
     tr = SolverTrace()
     tracing = store_trace || show_trace || extended_trace
     old_x = xs[:,1]
+    x_converged, f_converged, converged = false, false, false
 
     for n = 1:iterations
         # fixed-point iteration

--- a/src/nlsolve_func_defs.jl
+++ b/src/nlsolve_func_defs.jl
@@ -10,7 +10,7 @@ function nlsolve{T}(df::AbstractDifferentiableMultivariateFunction,
                  linesearch!::Function = no_linesearch!,
                  factor::Real = one(T),
                  autoscale::Bool = true,
-                 hist_size::Integer = 0,
+                 m::Integer = 0,
                  beta::Real = 1.0)
     if extended_trace
         show_trace = true
@@ -28,7 +28,7 @@ function nlsolve{T}(df::AbstractDifferentiableMultivariateFunction,
                      autoscale)
     elseif method == :anderson
         anderson(df, initial_x, xtol, ftol, iterations,
-                 store_trace, show_trace, extended_trace, hist_size, beta)
+                 store_trace, show_trace, extended_trace, m, beta)
     else
         throw(ArgumentError("Unknown method $method"))
     end
@@ -47,14 +47,14 @@ function nlsolve{T}(f!::Function,
                  linesearch!::Function = no_linesearch!,
                  factor::Real = one(T),
                  autoscale::Bool = true,
-                 hist_size::Integer = 0,
+                 m::Integer = 0,
                  beta::Real = 1.0)
     nlsolve(DifferentiableMultivariateFunction(f!, g!),
             initial_x, method = method, xtol = xtol, ftol = ftol,
             iterations = iterations, store_trace = store_trace,
             show_trace = show_trace, extended_trace = extended_trace,
             linesearch! = linesearch!, factor = factor, autoscale = autoscale,
-            hist_size = hist_size, beta = beta)
+            m = m, beta = beta)
 end
 
 function nlsolve{T}(f!::Function,
@@ -69,7 +69,7 @@ function nlsolve{T}(f!::Function,
                  linesearch!::Function = no_linesearch!,
                  factor::Real = one(T),
                  autoscale::Bool = true,
-                 hist_size::Integer = 0,
+                 m::Integer = 0,
                  beta::Real = 1.0,
                  autodiff::Bool = false)
     if !autodiff
@@ -82,5 +82,5 @@ function nlsolve{T}(f!::Function,
             iterations = iterations, store_trace = store_trace,
             show_trace = show_trace, extended_trace = extended_trace,
             linesearch! = linesearch!, factor = factor, autoscale = autoscale,
-            hist_size = hist_size, beta = beta)
+            m = m, beta = beta)
 end

--- a/src/nlsolve_func_defs.jl
+++ b/src/nlsolve_func_defs.jl
@@ -9,7 +9,9 @@ function nlsolve{T}(df::AbstractDifferentiableMultivariateFunction,
                  extended_trace::Bool = false,
                  linesearch!::Function = no_linesearch!,
                  factor::Real = one(T),
-                 autoscale::Bool = true)
+                 autoscale::Bool = true,
+                 hist_size::Integer = 0,
+                 beta::Real = 1.0)
     if extended_trace
         show_trace = true
     end
@@ -24,6 +26,9 @@ function nlsolve{T}(df::AbstractDifferentiableMultivariateFunction,
         trust_region(df, initial_x, xtol, ftol, iterations,
                      store_trace, show_trace, extended_trace, factor,
                      autoscale)
+    elseif method == :anderson
+        anderson(df, initial_x, xtol, ftol, iterations,
+                 store_trace, show_trace, extended_trace, hist_size, beta)
     else
         throw(ArgumentError("Unknown method $method"))
     end
@@ -41,12 +46,15 @@ function nlsolve{T}(f!::Function,
                  extended_trace::Bool = false,
                  linesearch!::Function = no_linesearch!,
                  factor::Real = one(T),
-                 autoscale::Bool = true)
+                 autoscale::Bool = true,
+                 hist_size::Integer = 0,
+                 beta::Real = 1.0)
     nlsolve(DifferentiableMultivariateFunction(f!, g!),
             initial_x, method = method, xtol = xtol, ftol = ftol,
             iterations = iterations, store_trace = store_trace,
             show_trace = show_trace, extended_trace = extended_trace,
-            linesearch! = linesearch!, factor = factor, autoscale = autoscale)
+            linesearch! = linesearch!, factor = factor, autoscale = autoscale,
+            hist_size = hist_size, beta = beta)
 end
 
 function nlsolve{T}(f!::Function,
@@ -61,6 +69,8 @@ function nlsolve{T}(f!::Function,
                  linesearch!::Function = no_linesearch!,
                  factor::Real = one(T),
                  autoscale::Bool = true,
+                 hist_size::Integer = 0,
+                 beta::Real = 1.0,
                  autodiff::Bool = false)
     if !autodiff
         df = DifferentiableMultivariateFunction(f!)
@@ -71,5 +81,6 @@ function nlsolve{T}(f!::Function,
             initial_x, method = method, xtol = xtol, ftol = ftol,
             iterations = iterations, store_trace = store_trace,
             show_trace = show_trace, extended_trace = extended_trace,
-            linesearch! = linesearch!, factor = factor, autoscale = autoscale)
+            linesearch! = linesearch!, factor = factor, autoscale = autoscale,
+            hist_size = hist_size, beta = beta)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,9 +8,9 @@ end
 
 wnorm{T}(w::Vector{T}, x::Vector{T}) = sqrt(wdot(w, x, x))
 
-function assess_convergence(x::Vector,
-                            x_previous::Vector,
-                            f::Vector,
+function assess_convergence(x::AbstractArray,
+                            x_previous::AbstractArray,
+                            f::AbstractArray,
                             xtol::Real,
                             ftol::Real)
     x_converged, f_converged = false, false

--- a/test/2by2.jl
+++ b/test/2by2.jl
@@ -44,7 +44,9 @@ r = nlsolve(df, [ -0.5f0; 1.4f0], method = :newton, linesearch! = LineSearches.b
 @test converged(r)
 @test norm(r.zero - [ 0; 1]) < 1e-6
 
-# test local convergence of Anderson
+# test local convergence of Anderson: close to a fixed-point and with
+# a small beta, f should be almost affine, in which case Anderson is
+# equivalent to GMRES and should converge
 r = nlsolve(df, [ 0.01; .99], method = :anderson, hist_size = 10, beta=.01)
 @test converged(r)
 @test norm(r.zero - [ 0; 1]) < 1e-8

--- a/test/2by2.jl
+++ b/test/2by2.jl
@@ -44,6 +44,10 @@ r = nlsolve(df, [ -0.5f0; 1.4f0], method = :newton, linesearch! = LineSearches.b
 @test converged(r)
 @test norm(r.zero - [ 0; 1]) < 1e-6
 
+# test local convergence of Anderson
+r = nlsolve(df, [ 0.01; .99], method = :anderson, hist_size = 10, beta=.01)
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-8
 
 # Tests of other lineasearches are disabled, they are not stable across runs
 #r = nlsolve(df, [ -0.5; 1.4], method = :newton, linesearch! = LineSearches.hz_linesearch!, ftol = 1e-6)

--- a/test/2by2.jl
+++ b/test/2by2.jl
@@ -47,7 +47,7 @@ r = nlsolve(df, [ -0.5f0; 1.4f0], method = :newton, linesearch! = LineSearches.b
 # test local convergence of Anderson: close to a fixed-point and with
 # a small beta, f should be almost affine, in which case Anderson is
 # equivalent to GMRES and should converge
-r = nlsolve(df, [ 0.01; .99], method = :anderson, hist_size = 10, beta=.01)
+r = nlsolve(df, [ 0.01; .99], method = :anderson, m = 10, beta=.01)
 @test converged(r)
 @test norm(r.zero - [ 0; 1]) < 1e-8
 


### PR DESCRIPTION
This is in response to https://github.com/JuliaNLSolvers/NLsolve.jl/issues/88. This is a very basic implementation of Anderson acceleration but it works fine enough for well-conditioned problems.

A better implementation would use updates to qr factors, not implemented in julia yet (https://github.com/JuliaLang/julia/issues/20791). This would enable a better scaling with the history size, and more stability (through condition number monitoring).