### PR TITLE
Update NLsolve to NLSolversBase and new LineSearches

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.6.0-pre
-Optim
 Calculus
 Distances
 ForwardDiff 0.5.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ Distances
 ForwardDiff 0.5.0
 LineSearches
 DiffBase
+NLSolversBase 2.1.0

--- a/src/NLsolve.jl
+++ b/src/NLsolve.jl
@@ -5,7 +5,6 @@ module NLsolve
 using Distances
 using NLSolversBase
 using LineSearches
-using Optim
 using ForwardDiff
 
 import Base.show,

--- a/src/NLsolve.jl
+++ b/src/NLsolve.jl
@@ -3,6 +3,7 @@ __precompile__()
 module NLsolve
 
 using Distances
+using NLSolversBase
 using LineSearches
 using Optim
 using ForwardDiff

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -1,4 +1,4 @@
-function no_linesearch!(dfo, xold, p, x, gr, lsr, alpha, mayterminate)
+function no_linesearch!(dfo, xold, p, x, lsr, alpha, mayterminate)
     @simd for i in eachindex(x)
         @inbounds x[i] = xold[i] + p[i]
     end
@@ -132,7 +132,7 @@ function newton_{T}(df::AbstractDifferentiableMultivariateFunction,
         LineSearches.clear!(lsr)
         push!(lsr, zero(T), dot(fvec,fvec)/2, dot(g, p))
 
-        alpha = linesearch!(dfo, xold, p, x, gr, lsr, one(T), mayterminate)
+        alpha = linesearch!(dfo, xold, p, x, lsr, one(T), mayterminate)
 
         # fvec is here also updated in the linesearch! so no need to call f again.
 

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -84,7 +84,7 @@ function newton_{T}(df::AbstractDifferentiableMultivariateFunction,
     # is expensive to recompute.
     # We solve this using the already computed ∇f(xₖ)
     # in case of the line search asking us for the gradient at xₖ.
-    function go!(xlin::Vector, storage::Vector)
+    function go!(storage::Vector, xlin::Vector)
         if xlin == xold
             At_mul_B!(storage, fjac, fvec)
         # Else we need to recompute it.
@@ -95,8 +95,8 @@ function newton_{T}(df::AbstractDifferentiableMultivariateFunction,
             At_mul_B!(storage, fjac, fvec)
         end
     end
-    function fgo!(xlin::Vector, storage::Vector)
-        go!(xlin, storage)
+    function fgo!(storage::Vector, xlin::Vector)
+        go!(storage, xlin)
         dot(fvec, fvec) / 2
     end
 

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -100,7 +100,7 @@ function newton_{T}(df::AbstractDifferentiableMultivariateFunction,
         dot(fvec, fvec) / 2
     end
 
-    dfo = DifferentiableFunction(fo, go!, fgo!)
+    dfo = OnceDifferentiable(fo, go!, fgo!, initial_x)
 
     while !converged && it < iterations
 


### PR DESCRIPTION
If we merge and tag this, I can fix Optim to not depend on ReverseDiff, fix the new ForwardDiff syntax, and tag a new version that is v0.6 only. 