### PR TITLE
New inplace keyword to replace not_in_place functions.

### DIFF
--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -34,30 +34,7 @@ function nlsolve(df::TDF,
     end
 end
 
-function nlsolve(f!,
-                 j!,
-                 initial_x::AbstractArray{T};
-                 method::Symbol = :trust_region,
-                 xtol::Real = zero(T),
-                 ftol::Real = convert(T, 1e-8),
-                 iterations::Integer = 1_000,
-                 store_trace::Bool = false,
-                 show_trace::Bool = false,
-                 extended_trace::Bool = false,
-                 linesearch = no_linesearch,
-                 factor::Real = one(T),
-                 autoscale::Bool = true,
-                 m::Integer = 0,
-                 beta::Real = 1.0) where T
-    nlsolve(OnceDifferentiable(f!, j!, initial_x, initial_x),
-            initial_x, method = method, xtol = xtol, ftol = ftol,
-            iterations = iterations, store_trace = store_trace,
-            show_trace = show_trace, extended_trace = extended_trace,
-            linesearch = linesearch, factor = factor, autoscale = autoscale,
-            m = m, beta = beta)
-end
-
-function nlsolve{T}(f!,
+function nlsolve{T}(f,
                  initial_x::AbstractArray{T};
                  method::Symbol = :trust_region,
                  xtol::Real = zero(T),
@@ -71,12 +48,78 @@ function nlsolve{T}(f!,
                  autoscale::Bool = true,
                  m::Integer = 0,
                  beta::Real = 1.0,
-                 autodiff = :forward)
-        df = OnceDifferentiable(f!, initial_x, initial_x, autodiff)
+                 autodiff = :forward,
+                 inplace = true)
+    if inplace
+        df = OnceDifferentiable(f, initial_x, initial_x, autodiff)
+    else
+        df = OnceDifferentiable(not_in_place(f), initial_x, initial_x, autodiff)
+    end
+    
     nlsolve(df,
             initial_x, method = method, xtol = xtol, ftol = ftol,
             iterations = iterations, store_trace = store_trace,
             show_trace = show_trace, extended_trace = extended_trace,
             linesearch = linesearch, factor = factor, autoscale = autoscale,
             m = m, beta = beta)
+end
+
+
+function nlsolve(f!,
+                j!,
+                initial_x::AbstractArray{T};
+                method::Symbol = :trust_region,
+                xtol::Real = zero(T),
+                ftol::Real = convert(T, 1e-8),
+                iterations::Integer = 1_000,
+                store_trace::Bool = false,
+                show_trace::Bool = false,
+                extended_trace::Bool = false,
+                linesearch = no_linesearch,
+                factor::Real = one(T),
+                autoscale::Bool = true,
+                m::Integer = 0,
+                beta::Real = 1.0,
+                inplace = true) where T
+    if inplace
+        df = OnceDifferentiable(f!, j!, initial_x, initial_x)
+    else
+        df = OnceDifferentiable(not_in_place(f!, j!)..., initial_x, initial_x)
+    end
+    nlsolve(df,
+    initial_x, method = method, xtol = xtol, ftol = ftol,
+    iterations = iterations, store_trace = store_trace,
+    show_trace = show_trace, extended_trace = extended_trace,
+    linesearch = linesearch, factor = factor, autoscale = autoscale,
+    m = m, beta = beta)
+end
+
+function nlsolve(f!,
+                j!,
+                fj!,
+                initial_x::AbstractArray{T};
+                method::Symbol = :trust_region,
+                xtol::Real = zero(T),
+                ftol::Real = convert(T, 1e-8),
+                iterations::Integer = 1_000,
+                store_trace::Bool = false,
+                show_trace::Bool = false,
+                extended_trace::Bool = false,
+                linesearch = no_linesearch,
+                factor::Real = one(T),
+                autoscale::Bool = true,
+                m::Integer = 0,
+                beta::Real = 1.0,
+                inplace = true) where T
+    if inplace
+        df = OnceDifferentiable(f!, j!, fj!, initial_x, initial_x)
+    else
+        df = OnceDifferentiable(not_in_place(f!, j!, fj!)..., initial_x, initial_x)
+    end
+    nlsolve(df,
+    initial_x, method = method, xtol = xtol, ftol = ftol,
+    iterations = iterations, store_trace = store_trace,
+    show_trace = show_trace, extended_trace = extended_trace,
+    linesearch = linesearch, factor = factor, autoscale = autoscale,
+    m = m, beta = beta)
 end

--- a/src/objectives/helpers.jl
+++ b/src/objectives/helpers.jl
@@ -1,3 +1,26 @@
+
+
+# Helpers for functions that do not modify arguments in place but return
+function not_in_place(f)
+    function f!(F, x)
+        copy!(F, f(x))
+    end
+end
+
+function not_in_place(f, j)
+    not_in_place(f), not_in_place(j)
+end
+
+function not_in_place(f, j, fj)
+    function fj!(F, J, x)
+        f, j = fj(x)
+        copy!(F, f)
+        copy!(J, j)
+    end
+    not_in_place(f, j)..., fj!
+end
+
+
 # Helper for functions that take several scalar arguments and return a tuple
 function n_ary(f)
     f!(fx, x) = copy!(fx, [f(x...)... ])

--- a/test/iface.jl
+++ b/test/iface.jl
@@ -81,20 +81,17 @@ function fg(x)
 end
 
 
-#FIXME Need to use the new interface
-#=
-r = nlsolve(not_in_place(f), [ -0.5; 1.4])
+r = nlsolve(f, [ -0.5; 1.4]; inplace = false)
 @test converged(r)
 
-r = nlsolve(not_in_place(f), [ -0.5; 1.4], autodiff = true)
+r = nlsolve(f, [ -0.5; 1.4]; inplace = false, autodiff = true)
 @test converged(r)
 
-r = nlsolve(not_in_place(f, g), [ -0.5; 1.4])
+r = nlsolve(f, g, [ -0.5; 1.4]; inplace = false)
 @test converged(r)
 
-r = nlsolve(not_in_place(f, g, fg), [ -0.5; 1.4])
+r = nlsolve(f, g, fg, [ -0.5; 1.4]; inplace = false)
 @test converged(r)
-=#
 
 # Using functions taking scalar as inputs
 


### PR DESCRIPTION
This should take care of the last unfinished business on current master. This is another breaking change. I've purged the `not_in_place` functions for an `inplace` keyword to `nlsolve`. I think a keyword like this should probably be added in Optim as well. Maybe it should be implemented in `NDifferentiable` constructors directly as well, but that'll have to wait.

See the new README here https://github.com/JuliaNLSolvers/NLsolve.jl/blob/62a7da8aec95e808fecae1a2a4427d8c2b9f2545/README.md

Any comments are welcome. I'll merge soon though and tag a new version. Then we can take any confusion or subtle bugs as they appear. We really need to get up to date with NLSolversBase to not block the ecosystem, and the same goes for the positional argument order change.