### PR TITLE
Correct for multidimensional functions

### DIFF
--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -20,7 +20,7 @@ function assess_convergence(x,
         x_converged = true
     end
 
-    if norm(f, Inf) < ftol
+    if maximum(abs, f) < ftol
         f_converged = true
     end
 


### PR DESCRIPTION
`norm(., Inf)` is not defined for arrays with dim > 2, so I have replaced it with `maximum(abs, .)`

```julia
norm(ones(10, 10, 10), Inf)
#> ERROR: MethodError: no method matching norm(::Array{Float64,3}, ::Float64)
maximum(abs, ones(10, 10, 10))
#> 1.0
```