### PR TITLE
 β to beta in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,15 +284,15 @@ vector and evaluate the function at the new point.
 This method is selected with `method = :anderson`.
 
 It is also known as DIIS or Pulay mixing, this method is based on the
-acceleration of the fixed-point iteration `xn+1 = xn + β f(xn)`, where
-by default `β=1`. It does not use Jacobian information or linesearch,
+acceleration of the fixed-point iteration `xₙ₊₁ = xₙ + beta*f(xₙ)`, where
+by default `beta=1`. It does not use Jacobian information or linesearch,
 but has a history whose size is controlled by the `m` parameter: `m=0`
 (the default) corresponds to the simple fixed-point iteration above,
 and higher values use a larger history size to accelerate the
 iterations. Higher values of `m` usually increase the speed of
 convergence, but increase the storage and computation requirements and
 might lead to instabilities. This method is useful to accelerate a
-fixed-point iteration `xn+1 = g(xn)` (in which case use this solver
+fixed-point iteration `xₙ₊₁ = g(xₙ)` (in which case use this solver
 with `f(x) = g(x) - x`).
 
 Reference: H. Walker, P. Ni, Anderson acceleration for fixed-point

--- a/src/solvers/anderson.jl
+++ b/src/solvers/anderson.jl
@@ -1,9 +1,9 @@
 # Notations from Walker & Ni, "Anderson acceleration for fixed-point iterations", SINUM 2011
-# Attempts to accelerate the iteration xn+1 = xn + β f(x)
+# Attempts to accelerate the iteration xₙ₊₁ = xₙ + beta*f(xₙ)
 
 struct Anderson{Tm, Tb}
     m::Tm
-    β::Tb
+    beta::Tb
 end
 struct AndersonCache{Txs, Tx, Ta, Tf} <: AbstractSolverCache
     xs::Txs
@@ -37,8 +37,8 @@ end
                              show_trace::Bool,
                              extended_trace::Bool,
                              m::Integer,
-                             β::Real,
-                             cache = AndersonCache(df, Anderson(m, β))) where T
+                             beta::Real,
+                             cache = AndersonCache(df, Anderson(m, beta))) where T
 
     copyto!(cache.xs[:,1], x0)
     iters = 0
@@ -53,7 +53,7 @@ end
         # fixed-point iteration
         value!!(df, cache.fx, cache.xs[:,1])
 
-        cache.gs[:,1] .= cache.xs[:,1] .+ β.*cache.fx
+        cache.gs[:,1] .= cache.xs[:,1] .+ beta.*cache.fx
 
         x_converged, f_converged, converged = assess_convergence(cache.gs[:,1], cache.old_x, cache.fx, xtol, ftol)
 
@@ -98,11 +98,11 @@ end
     end
 
     # returning gs[:,1] rather than xs[:,1] would be better here if
-    # xn+1 = xn+beta*f(xn) is convergent, but the convergence
+    # xₙ₊₁ = xₙ + beta*f(xₙ) is convergent, but the convergence
     # criterion is not guaranteed
     x = similar(x0)
     copyto!(x, cache.xs[:,1])
-    return SolverResults("Anderson m=$m β=$β",
+    return SolverResults("Anderson m=$m beta=$beta",
                          x0, x, maximum(abs,cache.fx),
                          iters, x_converged, xtol, f_converged, ftol, tr,
                          first(df.f_calls), 0)


### PR DESCRIPTION
the README reads 
"this method is based on the acceleration of the fixed-point iteration `xn+1 = xn + β f(xn)`, where
by default `β=1`"
but I had to delve into the source code to figure out that the right keyword argument is `beta`.

Here I'm changing the keyword `beta` to `β`.
As an alternative we could change `β` to  `beta` in the README.

Cheers,
Carlo