### PR TITLE
Fix some more Julia 0.7-beta deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ function f!(F, x)
 end
 
 r = mcpsolve(f!, [0., 0., 0., 0.], [Inf, Inf, Inf, Inf],
-             [1.25, 0., 0., 0.5], reformulation = :smooth, autodiff = true)
+             [1.25, 0., 0., 0.5], reformulation = :smooth, autodiff = :forward)
 ```
 
 The solution is:

--- a/src/solvers/newton.jl
+++ b/src/solvers/newton.jl
@@ -68,7 +68,7 @@ function newton_(df::OnceDifferentiable,
     # has the gradient ∇fo(x) = ∇f(x) ⋅ f(x)
     function fo(xlin)
         value!(df, xlin)
-        vecdot(value(df), value(df)) / 2
+        dot(value(df), value(df)) / 2
     end
 
     # The line search algorithm will want to first compute ∇fo(xₖ).
@@ -83,7 +83,7 @@ function newton_(df::OnceDifferentiable,
     function fgo!(storage, xlin)
         value_jacobian!(df, xlin)
         mul!(vec(storage), transpose(jacobian(df)), vecvalue)
-        vecdot(value(df), value(df)) / 2
+        dot(value(df), value(df)) / 2
     end
     dfo = OnceDifferentiable(fo, go!, fgo!, cache.x, real(zero(T)))
 
@@ -115,7 +115,7 @@ function newton_(df::OnceDifferentiable,
 
         value_gradient!(dfo, cache.x)
 
-        alpha, ϕalpha = linesearch(dfo, cache.x, cache.p, one(T), x_ls, value(dfo), vecdot(cache.g, cache.p))
+        alpha, ϕalpha = linesearch(dfo, cache.x, cache.p, one(T), x_ls, value(dfo), dot(cache.g, cache.p))
         # fvec is here also updated in the linesearch so no need to call f again.
         copyto!(cache.x, x_ls)
         x_converged, f_converged, converged = assess_convergence(cache.x, cache.xold, value(df), xtol, ftol)
@@ -124,7 +124,7 @@ function newton_(df::OnceDifferentiable,
     end
 
     return SolverResults("Newton with line-search",
-                         initial_x, copy(cache.x), vecnorm(value(df), Inf),
+                         initial_x, copy(cache.x), norm(value(df), Inf),
                          it, x_converged, xtol, f_converged, ftol, tr,
                          first(df.f_calls), first(df.df_calls))
 end

--- a/src/solvers/trust_region.jl
+++ b/src/solvers/trust_region.jl
@@ -52,7 +52,7 @@ function dogleg!(p::AbstractArray{T}, p_c::AbstractArray{T}, p_i,
     catch e
         if isa(e, LAPACKException) || isa(e, SingularException)
             # If Jacobian is singular, compute a least-squares solution to J*x+r=0
-            U, S, V = svd(full(J)) # Convert to full matrix because sparse SVD not implemented as of Julia 0.3
+            U, S, V = svd(convert(Matrix{T}, J)) # Convert to full matrix because sparse SVD not implemented as of Julia 0.3
             k = sum(S .> eps())
             mrinv = V * Matrix(Diagonal([1 ./ S[1:k]; zeros(eltype(S), length(S)-k)])) * U' # Moore-Penrose generalized inverse of J
             vecpi = vec(p_i)
@@ -132,8 +132,8 @@ function trust_region_(df::OnceDifferentiable,
         end
 
         return SolverResults(name,
-        #initial_x, reshape(cache.x, size(initial_x)...), vecnorm(cache.r, Inf),
-        initial_x, copy(cache.x), vecnorm(cache.r, Inf),
+        #initial_x, reshape(cache.x, size(initial_x)...), norm(cache.r, Inf),
+        initial_x, copy(cache.x), norm(cache.r, Inf),
         it, x_converged, xtol, f_converged, ftol, tr,
         first(df.f_calls), first(df.df_calls))
     end
@@ -210,7 +210,7 @@ function trust_region_(df::OnceDifferentiable,
         name *= " and autoscaling"
     end
     return SolverResults(name,
-                         initial_x, copy(cache.x), vecnorm(cache.r, Inf),
+                         initial_x, copy(cache.x), norm(cache.r, Inf),
                          it, x_converged, xtol, f_converged, ftol, tr,
                          first(df.f_calls), first(df.df_calls))
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -49,9 +49,9 @@ for method in (:trust_region, :newton, :anderson)
     @test typeof(r_matrix.zero) == typeof(initial_x_matrix)
     #@test typeof(r_wrapped.zero) == typeof(initial_x_wrapped)
 
-    r_AD = nlsolve(f!, initial_x, method = method, autodiff = true)
-    r_matrix_AD = nlsolve(f!, initial_x_matrix, method = method, autodiff = true)
-    #r_wrapped_AD = nlsolve(f!, initial_x_wrapped, method = method, autodiff = true)
+    r_AD = nlsolve(f!, initial_x, method = method, autodiff = :forward)
+    r_matrix_AD = nlsolve(f!, initial_x_matrix, method = method, autodiff = :forward)
+    #r_wrapped_AD = nlsolve(f!, initial_x_wrapped, method = method, autodiff = :forward)
 
     @test r_AD.zero == vec(r_matrix_AD.zero)
     #@test r_matrix_AD.zero == r_wrapped_AD.zero

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -5,7 +5,7 @@ function f!(fvec, x)
     fvec[2] = sin(x[2]*exp(x[1])-1)
 end
 
-r = nlsolve(f!, [ -0.5; 1.4], autodiff = true)
+r = nlsolve(f!, [ -0.5; 1.4], autodiff = :forward)
 @test converged(r)
 @test norm(r.zero - [ 0; 1]) < 1e-8
 

--- a/test/iface.jl
+++ b/test/iface.jl
@@ -84,7 +84,7 @@ end
 r = nlsolve(f, [ -0.5; 1.4]; inplace = false)
 @test converged(r)
 
-r = nlsolve(f, [ -0.5; 1.4]; inplace = false, autodiff = true)
+r = nlsolve(f, [ -0.5; 1.4]; inplace = false, autodiff = :forward)
 @test converged(r)
 
 r = nlsolve(f, g, [ -0.5; 1.4]; inplace = false)
@@ -103,7 +103,7 @@ end
 
 r = nlsolve(n_ary(f), [ -0.5; 1.4])
 @test converged(r)
-r = nlsolve(n_ary(f), [ -0.5; 1.4], autodiff = true)
+r = nlsolve(n_ary(f), [ -0.5; 1.4], autodiff = :forward)
 @test converged(r)
 
 @testset "andersont trace issue #160" begin

--- a/test/josephy.jl
+++ b/test/josephy.jl
@@ -47,7 +47,7 @@ r = mcpsolve(f!, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00
 @test converged(r)
 @test norm(r.zero - solution) < 1e-8
 
-r = mcpsolve(f!, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], reformulation = :smooth, autodiff = true)
+r = mcpsolve(f!, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], reformulation = :smooth, autodiff = :forward)
 @test converged(r)
 @test norm(r.zero - solution) < 1e-8
 
@@ -66,7 +66,7 @@ r = mcpsolve(f!, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00
 @test converged(r)
 @test norm(r.zero - solution) < 1e-8
 
-r = mcpsolve(f!, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], reformulation = :minmax, autodiff = true)
+r = mcpsolve(f!, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], reformulation = :minmax, autodiff = :forward)
 @test converged(r)
 @test norm(r.zero - solution) < 1e-8
 

--- a/test/minpack.jl
+++ b/test/minpack.jl
@@ -535,7 +535,7 @@ for (df, initial, name) in alltests
                 r.f_calls, r.g_calls, r.residual_norm, tot_time)
         @test converged(r)
         # with autodiff
-        tot_time2 = @elapsed r_AD = nlsolve(df.f, initial, method = method, autodiff = true)
+        tot_time2 = @elapsed r_AD = nlsolve(df.f, initial, method = method, autodiff = :forward)
         @printf("%-45s   %5d   %5d   %5d   %14e   %10e\n", name*"-"*string(method)*"-AD",
                 length(initial), r_AD.f_calls, r_AD.g_calls, r_AD.residual_norm, tot_time)
         if PRINT_FILE

--- a/test/no_linesearch.jl
+++ b/test/no_linesearch.jl
@@ -5,7 +5,7 @@ function f_nolin!(fvec, x)
     fvec[2] = sin(x[2]*exp(x[1])-1)
 end
 
-r = nlsolve(f_nolin!, [ -0.5; 1.4], autodiff = true, method = :newton, linesearch = LineSearches.Static())
+r = nlsolve(f_nolin!, [ -0.5; 1.4], autodiff = :forward, method = :newton, linesearch = LineSearches.Static())
 @test converged(r)
 
 end

--- a/test/throws.jl
+++ b/test/throws.jl
@@ -14,10 +14,10 @@ function f_nan!(F, x)
     return F
 end
 
-@test_throws IsFiniteException nlsolve(f_inf!, [ -0.5; 1.4], method = :trust_region, autodiff=true)
-@test_throws IsFiniteException nlsolve(f_inf!, [ -0.5; 1.4], method = :newton, autodiff=true)
+@test_throws IsFiniteException nlsolve(f_inf!, [ -0.5; 1.4], method = :trust_region, autodiff=:forward)
+@test_throws IsFiniteException nlsolve(f_inf!, [ -0.5; 1.4], method = :newton, autodiff=:forward)
 
-@test_throws IsFiniteException nlsolve(f_nan!, [ -0.5; 1.4], method = :trust_region, autodiff=true)
-@test_throws IsFiniteException nlsolve(f_nan!, [ -0.5; 1.4], method = :newton, autodiff=true)
+@test_throws IsFiniteException nlsolve(f_nan!, [ -0.5; 1.4], method = :trust_region, autodiff=:forward)
+@test_throws IsFiniteException nlsolve(f_nan!, [ -0.5; 1.4], method = :newton, autodiff=:forward)
 
 end # testset


### PR DESCRIPTION
This removes a few more Julia 0.7-beta deprecations. It changes `vecdot` -> `dot`, `vecnorm` -> `norm`, and `full` -> `convert`. It also adjusts the package tests to use `autodiff = :forward` where previously it was `autodiff = true`.

All tests now pass without deprecations.