### PR TITLE
Enable abstractarray tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ else
              "throws.jl",
              "f_g_counts.jl",
              "no_linesearch.jl",
-             #"abstractarray.jl",
+             "abstractarray.jl",
              "fixedpoint/fixedpoint.jl"]
 end
 


### PR DESCRIPTION
Not sure how @quinnj saw this, but I don't think this was meant to be disabled, or if it was then @arnavs will be able to tell us why :)