### PR TITLE
Update newton.jl

### DIFF
--- a/src/solvers/newton.jl
+++ b/src/solvers/newton.jl
@@ -105,7 +105,7 @@ function newton_(df::OnceDifferentiable,
                 # FIXME: better selection for lambda, see Nocedal & Wright p. 289
                 fjac2 = jacobian(df)'*jacobian(df)
                 lambda = convert(T,1e6)*sqrt(n*eps())*norm(fjac2, 1)
-                cache.p .= -(fjac2 + lambda * I)\vec(cache.g)
+                cache.p .= rehape(-(fjac2 + lambda * I)\vec(cache.g), size(cache.p))
             else
                 throw(e)
             end


### PR DESCRIPTION
This line fails because `cache.p` has the dimension of `cache.g`, not `vec(cache.g`). Ideally there should be a test for this but it seems to be removed in the test file.