### PR TITLE
broadcast for singular newton

### DIFF
--- a/src/solvers/newton.jl
+++ b/src/solvers/newton.jl
@@ -105,7 +105,7 @@ function newton_(df::OnceDifferentiable,
                 # FIXME: better selection for lambda, see Nocedal & Wright p. 289
                 fjac2 = jacobian(df)'*jacobian(df)
                 lambda = convert(T,1e6)*sqrt(n*eps())*norm(fjac2, 1)
-                cache.p .= -(fjac2 + lambda * I)\vec(cache.g)
+                cache.p .= reshape(-(fjac2 + lambda * I)\vec(cache.g), size(cache.p))
             else
                 throw(e)
             end

--- a/test/singular.jl
+++ b/test/singular.jl
@@ -20,7 +20,7 @@ df = OnceDifferentiable(f_sinj!, g_sinj!, [3.0, 0.0], [3.0, 0.0])
 df32 = OnceDifferentiable(f_sinj!, g_sinj!, [3.0f0, 0.0f0], [3.0f0, 0.0f0])
 
 # Test disabled, not stable across runs
-#r = nlsolve(df, [ 3.0; 0], method = :newton, ftol = 1e-5)
+r = nlsolve(df, [ 3.0; 0], method = :newton, ftol = 1e-5)
 #@assert converged(r)
 #@assert norm(r.zero) < 1e-5
 


### PR DESCRIPTION
The line failed because cache.p has the dimension of cache.g, not vec(cache.g). I have readded the test to make sure there is no runtime error, even though I do not assert convergence.