### PR TITLE
Use Walker's suggestions for Anderson acceleration

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,6 @@ julia> F
 * Broyden updating of Jacobian in trust-region
 * Homotopy methods
 * [LMMCP algorithm by C. Kanzow](http://www.mathematik.uni-wuerzburg.de/~kanzow/)
-* QR updating of the least-squares problem in the Anderson acceleration solver
 
 # Related Packages
 

--- a/src/nlsolve/fixedpoint.jl
+++ b/src/nlsolve/fixedpoint.jl
@@ -13,7 +13,8 @@ function fixedpoint(f,
     factor::Real = one(T),
     autoscale::Bool = true,
     m::Integer = 5,
-    beta::Real = 1.0,
+    beta::Real = 1,
+    droptol::Real = 0,
     autodiff::Symbol = :central,
     inplace::Bool = !applicable(f, initial_x)) where T
     # Check for weird case. (Causes to hang for now)
@@ -35,5 +36,5 @@ function fixedpoint(f,
             iterations = iterations, store_trace = store_trace,
             show_trace = show_trace, extended_trace = extended_trace,
             linesearch = linesearch, factor = factor, autoscale = autoscale,
-            m = m, beta = beta)
+            m = m, beta = beta, droptol = droptol)
 end

--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -12,7 +12,9 @@ function nlsolve(df::TDF,
                  factor::Real = one(T),
                  autoscale::Bool = true,
                  m::Integer = 0,
-                 beta::Real = 1.0) where {T, TDF <: Union{NonDifferentiable, OnceDifferentiable}}
+                 beta::Real = 1,
+                 aa_start::Integer = 1,
+                 droptol::Real = 0) where {T, TDF <: Union{NonDifferentiable, OnceDifferentiable}}
     if show_trace
         @printf "Iter     f(x) inf-norm    Step 2-norm \n"
         @printf "------   --------------   --------------\n"
@@ -26,7 +28,7 @@ function nlsolve(df::TDF,
                      autoscale)
     elseif method == :anderson
         anderson(df, initial_x, xtol, ftol, iterations,
-                 store_trace, show_trace, extended_trace, m, beta)
+                 store_trace, show_trace, extended_trace, m, beta, aa_start, droptol)
     elseif method == :broyden
         broyden(df, initial_x, xtol, ftol, iterations,
                 store_trace, show_trace, extended_trace, linesearch)
@@ -48,7 +50,9 @@ function nlsolve(f,
                  factor::Real = one(T),
                  autoscale::Bool = true,
                  m::Integer = 0,
-                 beta::Real = 1.0,
+                 beta::Real = 1,
+                 aa_start::Integer = 1,
+                 droptol::Real = 0,
                  autodiff = :central,
                  linsolve=(x, A, b) -> copyto!(x, A\b),
                  inplace = !applicable(f, initial_x)) where T
@@ -71,7 +75,7 @@ function nlsolve(f,
             iterations = iterations, store_trace = store_trace,
             show_trace = show_trace, extended_trace = extended_trace,
             linesearch = linesearch, factor = factor, autoscale = autoscale,
-            m = m, beta = beta, linsolve=linsolve)
+            m = m, beta = beta, aa_start = aa_start, droptol = droptol, linsolve=linsolve)
 end
 
 
@@ -89,7 +93,9 @@ function nlsolve(f,
                 factor::Real = one(T),
                 autoscale::Bool = true,
                 m::Integer = 0,
-                beta::Real = 1.0,
+                beta::Real = 1,
+                aa_start::Integer = 1,
+                droptol::Real = 0,
                 inplace = !applicable(f, initial_x),
                 linsolve=(x, A, b) -> copyto!(x, A\b)) where T
     if inplace
@@ -102,7 +108,7 @@ function nlsolve(f,
     iterations = iterations, store_trace = store_trace,
     show_trace = show_trace, extended_trace = extended_trace,
     linesearch = linesearch, factor = factor, autoscale = autoscale,
-    m = m, beta = beta, linsolve=linsolve)
+    m = m, beta = beta, aa_start = aa_start, droptol = droptol, linsolve=linsolve)
 end
 
 function nlsolve(f,
@@ -120,7 +126,9 @@ function nlsolve(f,
                 factor::Real = one(T),
                 autoscale::Bool = true,
                 m::Integer = 0,
-                beta::Real = 1.0,
+                beta::Real = 1,
+                aa_start::Integer = 1,
+                droptol::Real = 0,
                 inplace = !applicable(f, initial_x),
                 linsolve=(x, A, b) -> copyto!(x, A\b)) where T
     if inplace
@@ -133,5 +141,5 @@ function nlsolve(f,
     iterations = iterations, store_trace = store_trace,
     show_trace = show_trace, extended_trace = extended_trace,
     linesearch = linesearch, factor = factor, autoscale = autoscale,
-    m = m, beta = beta, linsolve=linsolve)
+    m = m, beta = beta, aa_start = aa_start, droptol = droptol, linsolve=linsolve)
 end

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -35,3 +35,63 @@ function check_isfinite(x::AbstractArray)
         throw(IsFiniteException(i))
     end
 end
+
+"""
+    qrdelete!(Q, R, k)
+
+Delete the left-most column of F = Q[:, 1:k] * R[1:k, 1:k] by updating Q and R.
+
+Only Q[:, 1:(k-1)] and R[1:(k-1), 1:(k-1)] are valid on exit.
+"""
+function qrdelete!(Q::AbstractMatrix, R::AbstractMatrix, k::Int)
+  n, m = size(Q)
+  m == LinearAlgebra.checksquare(R) || throw(DimensionMismatch())
+  1 ≤ k ≤ m || throw(ArgumentError())
+
+  # apply Givens rotations
+  for i in 2:k
+      g = first(givens(R, i - 1, i, i))
+      lmul!(g, R)
+      rmul!(Q, g')
+  end
+
+  # move columns of R
+  @inbounds for j in 1:(k-1)
+    for i in 1:(k-1)
+      R[i, j] = R[i, j + 1]
+    end
+  end
+
+  Q, R
+end
+
+"""
+    qradd!(Q, R, v, k)
+
+Replace the right-most column of F = Q[:, 1:k] * R[1:k, 1:k] with v by updating Q and R.
+
+This implementation modifies vector v as well. Only Q[:, 1:k] and R[1:k, 1:k] are valid on
+exit.
+"""
+function qradd!(Q::AbstractMatrix, R::AbstractMatrix, v::AbstractVector, k::Int)
+  n, m = size(Q)
+  n == length(v) || throw(DimensionMismatch())
+  m == LinearAlgebra.checksquare(R) || throw(DimensionMismatch())
+  1 ≤ k ≤ m || throw(ArgumentError())
+
+  @inbounds for i in 1:(k-1)
+    q = view(Q, :, i)
+    r = dot(q, v)
+
+    R[i, k] = r
+    axpy!(-r, q, v)
+  end
+
+  @inbounds begin
+    d = norm(v)
+    R[k, k] = d
+    @. Q[:, k] = v / d
+  end
+
+  Q, R
+end

--- a/src/solvers/anderson.jl
+++ b/src/solvers/anderson.jl
@@ -138,7 +138,7 @@ AndersonCache(df, ::Anderson{0}) =
                     while cond(R) > droptol && m_eff > 1
                         qrdelete!(cache.Q, cache.R, m_eff)
                         m_eff -= 1
-                        R = UpperTriangular(view(cache.R, 1:m_eff, 1:m_eff))
+                        Q, R = view(cache.Q, :, 1:m_eff), UpperTriangular(view(cache.R, 1:m_eff, 1:m_eff))
                     end
                 end
 

--- a/test/fixedpoint/fixedpoint.jl
+++ b/test/fixedpoint/fixedpoint.jl
@@ -57,6 +57,7 @@ end
 # Tests against the above example.
     @test fixedpoint(f_1!, [3.4, 4.3]).zero == fixedpoint(f_1, [3.4, 4.3]; inplace = false).zero ≈ [5.0, 4.571428571428571]
     @test fixedpoint(f_1!, [3.4, 4.3]; m = 2).zero == fixedpoint(f_1, [3.4, 4.3]; inplace = false, m = 2).zero ≈ [5.0, 4.571428571428571]
+    @test fixedpoint(f_1!, [3.4, 4.3]; droptol = 5).zero == fixedpoint(f_1, [3.4, 4.3]; inplace = false, droptol = 5).zero ≈ [5.0, 4.571428571428571] 
 
 # Tests for some common functions.
     # x -> sin.(x)

--- a/test/interface/caches.jl
+++ b/test/interface/caches.jl
@@ -15,11 +15,11 @@ ncp = copy(nc.p)
 r = NLsolve.newton(df, [ 1.; 1.], 0.1, 0.1, 100, false, false, false, LineSearches.Static(), nc)
 @test !(ncp == nc.p)
 
-ac = NLsolve.AndersonCache(df, NLsolve.Anderson(10, 0.9))
-ac.xs .= 22.0
-acxs = copy(ac.xs)
-r = NLsolve.anderson(df, [ 1.; 1.], 0.1, 0.1, 100, false, false, false, 10, 0.9, ac)
-@test !(acxs == ac.xs)
+ac = NLsolve.AndersonCache(df, NLsolve.Anderson{10}())
+ac.x .= 22.0
+acx = copy(ac.x)
+r = NLsolve.anderson(df, [ 1.; 1.], 0.1, 0.1, 100, false, false, false, 0.9, 1, 0, ac)
+@test !(acx == ac.x)
 
 ntc = NLsolve.NewtonTrustRegionCache(df)
 ntc.r_predict .= 22.0


### PR DESCRIPTION
The current implementation of Anderson acceleration uses a different formulation of the least-squares problem than what was suggested by Walker and Ni in https://users.wpi.edu/~walker/Papers/Walker-Ni,SINUM,V49,1715-1735.pdf and https://users.wpi.edu/~walker/Papers/anderson_accn_algs_imps.pdf, and recomputes the QR decomposition in every step. In this PR I tried to follow those recommendations.