### PR TITLE
Fix Anderson for inputs of arbitrary dimension

### DIFF
--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -11,10 +11,10 @@ function nlsolve(df::TDF,
                  linsolve=(x, A, b) -> copyto!(x, A\b),
                  factor::Real = one(real(T)),
                  autoscale::Bool = true,
-                 m::Integer = 0,
+                 m::Integer = 10,
                  beta::Real = 1,
                  aa_start::Integer = 1,
-                 droptol::Real = 0) where {T, TDF <: Union{NonDifferentiable, OnceDifferentiable}}
+                 droptol::Real = convert(real(T), 1e10)) where {T, TDF <: Union{NonDifferentiable, OnceDifferentiable}}
     if show_trace
         @printf "Iter     f(x) inf-norm    Step 2-norm \n"
         @printf "------   --------------   --------------\n"
@@ -49,10 +49,10 @@ function nlsolve(f,
                  linesearch = LineSearches.Static(),
                  factor::Real = one(real(T)),
                  autoscale::Bool = true,
-                 m::Integer = 0,
+                 m::Integer = 10,
                  beta::Real = 1,
                  aa_start::Integer = 1,
-                 droptol::Real = 0,
+                 droptol::Real = convert(real(T), 1e10),
                  autodiff = :central,
                  linsolve=(x, A, b) -> copyto!(x, A\b),
                  inplace = !applicable(f, initial_x)) where T
@@ -92,10 +92,10 @@ function nlsolve(f,
                 linesearch = LineSearches.Static(),
                 factor::Real = one(real(T)),
                 autoscale::Bool = true,
-                m::Integer = 0,
+                m::Integer = 10,
                 beta::Real = 1,
                 aa_start::Integer = 1,
-                droptol::Real = 0,
+                droptol::Real = convert(real(T), 1e10),
                 inplace = !applicable(f, initial_x),
                 linsolve=(x, A, b) -> copyto!(x, A\b)) where T
     if inplace
@@ -125,10 +125,10 @@ function nlsolve(f,
                 linesearch = LineSearches.Static(),
                 factor::Real = one(real(T)),
                 autoscale::Bool = true,
-                m::Integer = 0,
+                m::Integer = 10,
                 beta::Real = 1,
                 aa_start::Integer = 1,
-                droptol::Real = 0,
+                droptol::Real = convert(real(T), 1e10),
                 inplace = !applicable(f, initial_x),
                 linsolve=(x, A, b) -> copyto!(x, A\b)) where T
     if inplace

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -30,8 +30,8 @@ function assess_convergence(x,
 end
 
 function check_isfinite(x::AbstractArray)
-    if any((y)->!isfinite(y),x)
-        i = findall((!).(isfinite.(x)))
+    if any(!isfinite, x)
+        i = findall(!isfinite, x)
         throw(IsFiniteException(i))
     end
 end

--- a/src/solvers/anderson.jl
+++ b/src/solvers/anderson.jl
@@ -45,7 +45,7 @@ function AndersonCache(df, m)
 end
 
 @views function anderson_(df::Union{NonDifferentiable, OnceDifferentiable},
-                             initial_x::AbstractArray{T},
+                             initial_x::AbstractArray,
                              xtol::Real,
                              ftol::Real,
                              iterations::Integer,
@@ -55,7 +55,7 @@ end
                              beta::Real,
                              aa_start::Integer,
                              droptol::Real,
-                             cache::AndersonCache) where T
+                             cache::AndersonCache)
     copyto!(cache.x, initial_x)
     tr = SolverTrace()
     tracing = store_trace || show_trace || extended_trace
@@ -89,7 +89,7 @@ end
             update!(tr,
                     iter,
                     maximum(abs, fx),
-                    iter > 1 ? sqeuclidean(cache.g, cache.x) : convert(real(T),NaN),
+                    iter > 1 ? sqeuclidean(cache.g, cache.x) : convert(real(eltype(initial_x)), NaN),
                     dt,
                     store_trace,
                     show_trace)
@@ -185,16 +185,16 @@ function anderson(df::Union{NonDifferentiable, OnceDifferentiable},
 end
 
 function anderson(df::Union{NonDifferentiable, OnceDifferentiable},
-                     initial_x::AbstractArray{T},
-                     xtol::Real,
-                     ftol::Real,
-                     iterations::Integer,
-                     store_trace::Bool,
-                     show_trace::Bool,
-                     extended_trace::Bool,
-                     beta::Real,
-                     aa_start::Integer,
-                     droptol::Real,
-                     cache::AndersonCache) where T
-    anderson_(df, initial_x, convert(real(T), xtol), convert(real(T), ftol), iterations, store_trace, show_trace, extended_trace, beta, aa_start, droptol, cache)
+                  initial_x::AbstractArray,
+                  xtol::Real,
+                  ftol::Real,
+                  iterations::Integer,
+                  store_trace::Bool,
+                  show_trace::Bool,
+                  extended_trace::Bool,
+                  beta::Real,
+                  aa_start::Integer,
+                  droptol::Real,
+                  cache::AndersonCache)
+    anderson_(df, initial_x, convert(real(eltype(initial_x)), xtol), convert(real(eltype(initial_x)), ftol), iterations, store_trace, show_trace, extended_trace, beta, aa_start, droptol, cache)
 end

--- a/src/solvers/anderson.jl
+++ b/src/solvers/anderson.jl
@@ -153,7 +153,7 @@ end
 
                 # solve least squares problem
                 γs = view(cache.γs, 1:m_eff)
-                ldiv!(R, mul!(γs, Q', fx))
+                ldiv!(R, mul!(γs, Q', vec(fx)))
 
                 # update next iterate
                 for i in 1:m_eff

--- a/src/solvers/anderson.jl
+++ b/src/solvers/anderson.jl
@@ -69,9 +69,14 @@ end
     while iter < iterations
         iter += 1
 
-        # fixed-point iteration
+        # evaluate function
         value!!(df, cache.x)
         fx = value(df)
+
+        # check that all values are finite
+        check_isfinite(fx)
+
+        # compute next iterate of fixed-point iteration
         @. cache.g = cache.x + beta * fx
 
         # save trace
@@ -94,7 +99,7 @@ end
         x_converged, f_converged, converged = assess_convergence(cache.g, cache.x, fx, xtol, ftol)
         converged && break
 
-        # define next iterate
+        # update current iterate
         copyto!(cache.x, cache.g)
 
         # perform Anderson acceleration

--- a/test/2by2.jl
+++ b/test/2by2.jl
@@ -72,4 +72,9 @@ r = nlsolve(df, [ -0.5; 1.4], method = :newton, linesearch = LineSearches.Strong
 r = nlsolve(df, [ 0.01; .99], method = :anderson, m = 10, beta=.01)
 @test converged(r)
 @test norm(r.zero - [ 0; 1]) < 1e-8
+@test r.iterations == 9
+
+# without Anderson acceleration fixed-point iteration does not converge in 1_000 iterations
+r = nlsolve(df, [ 0.01; .99], method = :anderson, m = 0, beta=.01)
+@test !converged(r)
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -37,8 +37,8 @@ initial_x = vec(initial_x_matrix)
 #initial_x_wrapped = WrappedArray(initial_x_matrix)
 
 for method in (:trust_region, :newton, :anderson, :broyden)
-    r = nlsolve(f!, j!, initial_x, method = method)
-    r_matrix = nlsolve(f!, j!, initial_x_matrix, method = method)
+    r = nlsolve(f!, j!, initial_x, method = method, m = 2, beta = 1e-3)
+    r_matrix = nlsolve(f!, j!, initial_x_matrix, method = method, m = 2, beta = 1e-3)
     #r_wrapped = nlsolve(f!, j!, initial_x_wrapped, method = method)
 
     @test r.zero == vec(r_matrix.zero)
@@ -48,8 +48,9 @@ for method in (:trust_region, :newton, :anderson, :broyden)
     @test typeof(r.zero) == typeof(initial_x)
     @test typeof(r_matrix.zero) == typeof(initial_x_matrix)
     #@test typeof(r_wrapped.zero) == typeof(initial_x_wrapped)
-    r_AD = nlsolve(f!, initial_x, method = method, autodiff = :forward)
-    r_matrix_AD = nlsolve(f!, initial_x_matrix, method = method, autodiff = :forward)
+
+    r_AD = nlsolve(f!, initial_x, method = method, m = 2, beta = 1e-3, autodiff = :forward)
+    r_matrix_AD = nlsolve(f!, initial_x_matrix, method = method, m = 2, beta = 1e-3, autodiff = :forward)
     #r_wrapped_AD = nlsolve(f!, initial_x_wrapped, method = method, autodiff = :forward)
 
     @test r_AD.zero == vec(r_matrix_AD.zero)

--- a/test/iface.jl
+++ b/test/iface.jl
@@ -106,7 +106,7 @@ r = nlsolve(n_ary(f), [ -0.5; 1.4])
 r = nlsolve(n_ary(f), [ -0.5; 1.4], autodiff = :forward)
 @test converged(r)
 
-@testset "andersont trace issue #160" begin
+@testset "anderson trace issue #160" begin
 
     function f_2by2!(F, x)
         F[1] = (x[1]+3)*(x[2]^3-7)+18

--- a/test/interface/caches.jl
+++ b/test/interface/caches.jl
@@ -15,7 +15,7 @@ ncp = copy(nc.p)
 r = NLsolve.newton(df, [ 1.; 1.], 0.1, 0.1, 100, false, false, false, LineSearches.Static(), nc)
 @test !(ncp == nc.p)
 
-ac = NLsolve.AndersonCache(df, NLsolve.Anderson{10}())
+ac = NLsolve.AndersonCache(df, 10)
 ac.x .= 22.0
 acx = copy(ac.x)
 r = NLsolve.anderson(df, [ 1.; 1.], 0.1, 0.1, 100, false, false, false, 0.9, 1, 0, ac)


### PR DESCRIPTION
This PR fixes the use of matrices (and higher-dimensional arrays) as inputs for Anderson.

The issue was not detected by the tests since `m = 0` was the default history size. I changed the defaults to `m = 10` and `droptol = 1e10`, as used in [Walker's implementation](https://users.wpi.edu/~walker/Papers/anderson_accn_algs_imps.pdf).

However, for the default setting `beta = 1` the Wood example diverges, leading to infinite values in the standard fixed-point iteration and `NaN` with Anderson acceleration (due to the computation of `Q` and `R`). Thus I explicitly chose `m = 2` and `beta = 1e-3`, such that the algorithm does not diverge within the first 1000 iterations, and added a check for finite values in the algorithm.

Moreover, I removed the `Anderson` struct which seemed unnecessary.