### PR TITLE
Add tools to extract x, F, and J from the trace.

### DIFF
--- a/src/NLsolve.jl
+++ b/src/NLsolve.jl
@@ -52,4 +52,6 @@ include("nlsolve/nlsolve.jl")
 include("nlsolve/utils.jl")
 include("nlsolve/fixedpoint.jl")
 
+include("trace_tools.jl")
+
 end # module

--- a/src/trace_tools.jl
+++ b/src/trace_tools.jl
@@ -1,0 +1,16 @@
+trace(r::SolverResults) = r.trace
+function x_trace(r::SolverResults)
+    tr = trace(r).states
+    !haskey(tr[1].metadata, "x") && error("Trace does not contain x. To get a trace of x, run nlsolve() with extended_trace = true")
+    [ state.metadata["x"] for state in tr ]
+end
+function F_trace(r::SolverResults)
+    tr = trace(r).states
+    !haskey(tr[1].metadata, "f(x)") && error("Trace does not contain F. To get a trace of the residuals, run nlsolve() with extended_trace = true")
+    [ state.metadata["f(x)"] for state in tr ]
+end
+function J_trace(r::SolverResults)
+    tr = trace(r).states
+    !haskey(tr[1].metadata, "g(x)") && error("Trace does not contain J. To get a trace of the Jacobian, run nlsolve() with extended_trace = true")
+    [ state.metadata["g(x)"] for state in tr ]
+end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -32,5 +32,8 @@ for linesearches in [BackTracking(),StrongWolfe(),HagerZhang(),MoreThuente()] #S
     @test sol.g_calls == sol_real.g_calls
     @test all(sol_real.trace[i].stepnorm == sol_real.trace[i].stepnorm for i in 2:sol.iterations)
     @test all(norm(sol.trace[i].metadata["f(x)"]) ≈ norm(sol_real.trace[i].metadata["f(x)"]) for i in 1:5)
+    NLsolve.x_trace(sol_real)
+    NLsolve.F_trace(sol_real)
+    NLsolve.J_trace(sol_real)
 end
 end


### PR DESCRIPTION
Fixes #246 by adding `x_trace`, `F_trace`and `J_trace`. `extended_trace` has to be set to store arrays and not just norms.