### PR TITLE
Add a naive project_region! option for Newton method

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,12 @@ By default, no linesearch is performed.
 **Note:** it is assumed that a passed linesearch function will at least update the solution
 vector and evaluate the function at the new point.
 
+Added in sjdaines fork: if `linesearch=LineSearches.Static()` (the default), an additional argument
+`project_region!` (default value `(x)->(nothing)`) can be used to define a function to modify the proposed new
+`x` value after the Newton iteration. eg `project_region! = (x)->(x .= max.(x, 1e-80))` will enforce a constraint
+`x[i] >= 1e-80`.
+
+
 ## Anderson acceleration
 
 This method is selected with `method = :anderson`.

--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -9,6 +9,7 @@ function nlsolve(df::Union{NonDifferentiable, OnceDifferentiable},
                  extended_trace::Bool = false,
                  linesearch = LineSearches.Static(),
                  linsolve=(x, A, b) -> copyto!(x, A\b),
+                 project_region! = (x) -> (nothing),
                  factor::Real = one(real(eltype(initial_x))),
                  autoscale::Bool = true,
                  m::Integer = 10,
@@ -21,7 +22,7 @@ function nlsolve(df::Union{NonDifferentiable, OnceDifferentiable},
     end
     if method == :newton
         newton(df, initial_x, xtol, ftol, iterations,
-               store_trace, show_trace, extended_trace, linesearch; linsolve=linsolve)
+               store_trace, show_trace, extended_trace, linesearch; linsolve=linsolve, project_region! = project_region!)
     elseif method == :trust_region
         trust_region(df, initial_x, xtol, ftol, iterations,
                      store_trace, show_trace, extended_trace, factor,

--- a/src/solvers/newton.jl
+++ b/src/solvers/newton.jl
@@ -42,6 +42,7 @@ function newton_(df::OnceDifferentiable,
                  extended_trace::Bool,
                  linesearch,
                  linsolve,
+                 project_region!,
                  cache = NewtonCache(df)) where T
     n = length(initial_x)
     copyto!(cache.x, initial_x)
@@ -111,6 +112,7 @@ function newton_(df::OnceDifferentiable,
 
         if linesearch isa Static
             x_ls .= cache.x .+ cache.p
+            project_region!(x_ls)
             value_jacobian!(df, x_ls)
             alpha, ϕalpha = one(real(T)), value(dfo)
         else
@@ -142,6 +144,7 @@ function newton(df::OnceDifferentiable,
                 extended_trace::Bool,
                 linesearch,
                 cache = NewtonCache(df);
-                linsolve=(x, A, b) -> copyto!(x, A\b)) where T
-    newton_(df, initial_x, convert(real(T), xtol), convert(real(T), ftol), iterations, store_trace, show_trace, extended_trace, linesearch, linsolve, cache)
+                linsolve=(x, A, b) -> copyto!(x, A\b),
+                project_region! = (x) -> (nothing)) where T
+    newton_(df, initial_x, convert(real(T), xtol), convert(real(T), ftol), iterations, store_trace, show_trace, extended_trace, linesearch, linsolve, project_region!, cache)
 end


### PR DESCRIPTION
Adds minimal option to modify Newton steps eg to project to region maintaining positive concentrations for chemical kinetics problems.

If using `method=:newton` with `linesearch=LineSearches.Static()` (the default linesearch), an additional argument `project_region!` (default value `(x)->(nothing)`) can be used to define a function to modify the proposed new `x` value after each Newton iteration.

For example, `project_region! = (x) -> (x .= max.(x, 1e-80))` will enforce a constraint `x[i] >= 1e-80`.