### PR TITLE
Add new Broyden version:

### DIFF
--- a/src/nlsolve/nlsolve.jl
+++ b/src/nlsolve/nlsolve.jl
@@ -43,7 +43,7 @@ function nlsolve(f,
                  autodiff = :central,
                  inplace = !applicable(f, initial_x),
                  kwargs...)
-    if method in (:anderson, :broyden)
+    if (method == :anderson) || ((method == :broyden) && (autodiff == :central))
         df = NonDifferentiable(f, initial_x, copy(initial_x); inplace=inplace)
     else
         df = OnceDifferentiable(f, initial_x, copy(initial_x); autodiff=autodiff, inplace=inplace)


### PR DESCRIPTION
In my use case the approximate norm descents slows down the computation by factor 10. Moreover, I can just initialize the inverse Jacobian with it's true value at the initial x without noticable additional costs.

I, however, don't know whether this is the proper approach to modify the API...