### PR TITLE
handle underflow of norm(J[:,i])^2

### DIFF
--- a/src/solvers/trust_region.jl
+++ b/src/solvers/trust_region.jl
@@ -148,12 +148,12 @@ function trust_region_(df::OnceDifferentiable,
     if autoscale
         for j = 1:nn
             cache.d[j] = norm(view(jacobian(df), :, j))
-            if cache.d[j] == zero(cache.d[j])
-                cache.d[j] = one(cache.d[j])
+            if iszero(cache.d[j]^2) # square to catch underflow
+                cache.d[j] = oneunit(cache.d[j])
             end
         end
     else
-        fill!(cache.d, one(real(T)))
+        fill!(cache.d, oneunit(real(T)))
     end
 
     delta = factor * wnorm(cache.d, cache.x)


### PR DESCRIPTION
Someone mentioned on [Julia discourse](https://discourse.julialang.org/t/bug-in-nlsolve/135660?u=stevengj) that the `g ./ d.^2` computation in `dogleg!` is failing when `d.^2` is underflowing.  The code had checked for `d[i] == 0` but not for underflow.

This is a simple fix that checks `d[i]^2 == 0` instead.

(Also, while I was at it I changed `one` to `oneunit` at the same place in the code to be more dimensionfully correct.  It doesn't affect computations with dimensionless numbers.  However, if the code hasn't been tested with Unitful.jl or similar then I would assume that there are other dimension bugs elsewhere.)