### PR TITLE
Fix CI so tests run again

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,29 +1,34 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - master
-    tags: '*'
-  pull_request:
+  - push
+  - pull_request
 
 jobs:
   test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        julia-version: ['1.0', '1', 'nightly']
-        os: [ubuntu-latest, macOS-latest]
-
+        version:
+          - "lts"
+          - "1"
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: julia-actions/setup-julia@2
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
-        if: ${{ matrix.julia-version == '1' && matrix.os == 'ubuntu-latest' }}
+      - uses: codecov/codecov-action@v6
         with:
+          fail_ci_if_error: true
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -18,11 +18,10 @@ Reexport = "0.2, 1.0"
 julia = "1"
 
 [extras]
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DiffEqBase", "IterativeSolvers", "Random", "SparseArrays", "Test"]
+test = ["IterativeSolvers", "Random", "SparseArrays", "Test"]

--- a/src/solvers/newton.jl
+++ b/src/solvers/newton.jl
@@ -78,7 +78,7 @@ function newton_(df::OnceDifferentiable,
     function fgo!(storage, xlin)
         value_jacobian!(df, xlin)
         mul!(vec(storage), (jacobian(df))', vecvalue)
-        dot(value(df), value(df)) / 2
+        real(dot(value(df), value(df))) / 2
     end
     dfo = OnceDifferentiable(fo, go!, fgo!, cache.x, zero(real(T)))
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1,4 +1,3 @@
-
 @testset "complex" begin
 function f!(F, x)
   F[1] = x[1]*x[2] + (1+im)
@@ -8,29 +7,47 @@ function f_real!(F::AbstractArray{T}, x::AbstractArray{T}) where {T<:Real}
   f!(reinterpret(Complex{T}, F), reinterpret(Complex{T}, x))
 end
 
-for alg in [:newton,:trust_region,:anderson] # TODO add broyden
-    sol = nlsolve(f!, [1.0+0.1im, 2+1im], method = alg, store_trace=true, extended_trace=true, iterations=100, m=10, beta=0.01)
-    sol_real = nlsolve(f_real!, reinterpret(Float64, [1.0+0.1im, 2+1im]), method = alg, store_trace=true, extended_trace=true, iterations=100, m=10, beta=0.01)
+solver_kwargs = (store_trace = true, extended_trace = true, iterations = 100, m = 10, beta = 0.01)
 
-    @test converged(sol) == converged(sol_real)
-    @test sol.zero ≈ reinterpret(ComplexF64, sol_real.zero)
-    if alg in (:newton, :trust_region) #those are supposed to be exactly the same (in exact arithmetic)
-        @test sol.iterations == sol_real.iterations
-        @test sol.f_calls == sol_real.f_calls
-        @test sol.g_calls == sol_real.g_calls
-        @test all(sol_real.trace[i].stepnorm == sol_real.trace[i].stepnorm for i in 2:sol.iterations)
-        @test all(norm(sol.trace[i].metadata["f(x)"]) ≈ norm(sol_real.trace[i].metadata["f(x)"]) for i in 1:5)
+# Solving the real-embedded problem means passing
+# reinterpret(Float64, ::Vector{ComplexF64}) as initial_x. NLSolversBase seeds
+# DifferentiationInterface's preparation with the array it is handed but
+# evaluates with copy(x), and copy narrows a ReinterpretArray to a plain
+# Vector, so DI's strict check rejects every evaluation with a
+# PreparationMismatchError. This hits the methods that build a
+# OnceDifferentiable; anderson builds a NonDifferentiable, prepares no
+# jacobian, and is unaffected. Marked broken until NLSolversBase prepares
+# against the array it evaluates with.
+function agrees_with_real_embedding(sol, method, linesearch)
+    sol_real = nlsolve(f_real!, reinterpret(Float64, [1.0+0.1im, 2+1im]);
+                       method = method, linesearch = linesearch, solver_kwargs...)
+    agrees = converged(sol) == converged(sol_real) &&
+             sol.zero ≈ reinterpret(ComplexF64, sol_real.zero)
+    if method in (:newton, :trust_region) # these are supposed to be exactly the same (in exact arithmetic)
+        agrees &= sol.iterations == sol_real.iterations &&
+                  sol.f_calls == sol_real.f_calls &&
+                  sol.g_calls == sol_real.g_calls &&
+                  all(sol_real.trace[i].stepnorm == sol_real.trace[i].stepnorm for i in 2:sol.iterations) &&
+                  all(norm(sol.trace[i].metadata["f(x)"]) ≈ norm(sol_real.trace[i].metadata["f(x)"]) for i in 1:5)
+    end
+    return agrees
+end
+
+for method in [:newton, :trust_region, :anderson] # TODO add broyden
+    sol = nlsolve(f!, [1.0+0.1im, 2+1im]; method = method, solver_kwargs...)
+    @test converged(sol)
+    @test sol.residual_norm < 1e-8
+    if method === :anderson
+        @test agrees_with_real_embedding(sol, method, Static())
+    else
+        @test_broken agrees_with_real_embedding(sol, method, Static())
     end
 end
-for linesearches in [BackTracking(),StrongWolfe(),HagerZhang(),MoreThuente()] #Static is already included in default Newton without linesearch
-    sol = nlsolve(f!, [1.0+0.1im, 2+1im], method = :newton, linesearch=linesearches,store_trace=true, extended_trace=true, iterations=100, m=10, beta=0.01)
-    sol_real = nlsolve(f_real!, reinterpret(Float64, [1.0+0.1im, 2+1im]), method = :newton, linesearch=linesearches, store_trace=true, extended_trace=true, iterations=100, m=10, beta=0.01)
-    @test converged(sol) == converged(sol_real)
-    @test sol.zero ≈ reinterpret(ComplexF64, sol_real.zero)
-    @test sol.iterations == sol_real.iterations
-    @test sol.f_calls == sol_real.f_calls
-    @test sol.g_calls == sol_real.g_calls
-    @test all(sol_real.trace[i].stepnorm == sol_real.trace[i].stepnorm for i in 2:sol.iterations)
-    @test all(norm(sol.trace[i].metadata["f(x)"]) ≈ norm(sol_real.trace[i].metadata["f(x)"]) for i in 1:5)
+
+for linesearch in [BackTracking(), StrongWolfe(), HagerZhang(), MoreThuente()] # Static is covered above
+    sol = nlsolve(f!, [1.0+0.1im, 2+1im]; method = :newton, linesearch = linesearch, solver_kwargs...)
+    @test converged(sol)
+    @test sol.residual_norm < 1e-8
+    @test_broken agrees_with_real_embedding(sol, :newton, linesearch)
 end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,22 +1,13 @@
 using NLsolve
-using DiffEqBase
 using Test
 using NLSolversBase
 using LineSearches
 using LinearAlgebra
-import Base.convert
 using SparseArrays
 using Printf
 using IterativeSolvers
 using Random
 add_jl(x) = endswith(x, ".jl") ? x : x*".jl"
-
-mutable struct WrappedArray{T,N} <: DEDataArray{T,N}
-    x::Array{T,N}
-end
-
-Base.reshape(A::WrappedArray, dims::Int...) = WrappedArray(reshape(A.x, dims...))
-Base.convert(A::Type{WrappedArray{T,N}}, B::Array{T,N}) where {T,N} = WrappedArray(copy(B))
 
 if length(ARGS) > 0
     tests = map(add_jl, ARGS)


### PR DESCRIPTION
CI has not run on this repo since #292 landed on 2 Dec 2025. This gets it running again, and fixes the first of two things that were broken underneath it.

## The workflow could not start

`CI.yml` referenced `julia-actions/setup-julia@2`. There is no such ref; the action publishes `v1`/`v2`/`v3`. GitHub could not resolve the action, so every job failed in under 10 seconds having executed zero steps. Both runs after #292 look like this:

```
test (1, ubuntu-latest)        failure   steps: []
test (1.0, ubuntu-latest)      failure   steps: []
test (nightly, ubuntu-latest)  cancelled steps: []
...
```

The workflow is now modelled on Optim.jl's:

- `setup-julia@v3`, `checkout@v6`, `julia-buildpkg@v1`, `julia-runtest@v1`, `codecov-action@v6`
- added `julia-actions/cache@v3`
- matrix is `lts` and `1` rather than `1.0` and `nightly`, and adds `windows-latest`
- `fail-fast: false`, so one bad cell no longer cancels the others
- coverage uploads from every cell, with `CODECOV_TOKEN`

`min` is deliberately absent, even though Optim.jl tests it. This package declares `julia = "1"`, so `min` resolves to 1.0.0 and would put CI straight back in the red. Adding it means bumping the compat bound to `"1.10"` in line with Optim/LineSearches/NLSolversBase, which is a support-policy decision and wants its own PR.

## The test suite could not load

`runtests.jl` defined `WrappedArray{T,N} <: DEDataArray{T,N}`, and `DEDataArray` no longer exists in DiffEqBase, so the suite raised `UndefVarError` before running a single test.

Every use of `WrappedArray` is commented out in `test/abstractarray.jl` (lines 37, 42, 45, 47, 50, 54, 57, 59, 62), so the type definition and its two `Base` methods were the only live references to it. Removed, along with `using DiffEqBase`, the `import Base.convert` that existed only to support it, and DiffEqBase from the test target. No coverage is lost. Restoring a custom-array test would be worth doing on its own terms, with a plain `AbstractArray` subtype.

## A real bug the dead CI was hiding

With the suite loading again, `test/complex.jl` turned up a genuine bug in `newton.jl`. `fo` computes the merit function as `real(dot(value(df), value(df))) / 2`, but `fgo!` computed `dot(value(df), value(df)) / 2` with no `real()`. For a complex-valued `f`, `dot` returns a `Complex` with a tiny imaginary part, and the linesearch objective stores `F` as `zero(real(T))`, so the assignment threw:

```
InexactError: Float64(34.52505 + 3.5438318946035e-16im)
```

Every non-`Static` linesearch was therefore unusable on complex problems. All four threw on the first iteration; all four converge with `real()` added:

| linesearch | before | after |
| --- | --- | --- |
| `BackTracking` | `InexactError` | converged, resnorm 2.4e-11 |
| `StrongWolfe` | `InexactError` | converged, resnorm 1.3e-12 |
| `HagerZhang` | `InexactError` | converged, resnorm 4.9e-15 |
| `MoreThuente` | `InexactError` | converged, resnorm 8.0e-11 |

`test/complex.jl` exercises exactly this and never caught it, because the DI error below aborted the testset before reaching that loop.

## Marked broken: the real-embedded comparison

`test/complex.jl` also errored with a `PreparationMismatchError` from DifferentiationInterface, which is what aborted the testset and took `interface/caches.jl` and `fixedpoint/fixedpoint.jl` down with it, since neither had been running at all. That one is upstream and is marked `@test_broken` here rather than fixed.

It reproduces with no NLsolve involved, on NLSolversBase 7.10.0 / Julia 1.10.11:

```julia
using NLSolversBase
f!(F, x) = (F[1] = x[1]^2 - 2; F[2] = x[2]^2 - 3)

x0 = reinterpret(Float64, [1.0+1.0im])
typeof(x0)          # Base.ReinterpretArray{Float64, 1, ComplexF64, Vector{ComplexF64}, false}

df = OnceDifferentiable(f!, x0, copy(x0); autodiff=:central)
typeof(df.x_f)      # Vector{Float64}

value_jacobian!!(df, copy(df.x_f))   # PreparationMismatchError
```

```
PreparationMismatchError (inconsistent types between preparation and execution):
  - f!: ✅
  - y: ✅
  - backend: ✅
  - x: ❌
    - prep: Base.ReinterpretArray{Float64, 1, ComplexF64, Vector{ComplexF64}, false}
    - exec: Vector{Float64}
  - contexts: ✅
```

The finite-difference branch of the `OnceDifferentiable` constructor calls `DI.prepare_jacobian(f, F2, backend, x_seed)` at `src/objective_types/oncedifferentiable.jl:83`, seeding preparation with the array the caller passed in. The object then stores `x_f` and `x_df` as `copy(x)`, and `copy` of a `ReinterpretArray` returns a plain `Vector`. Every subsequent evaluation hands DI a type preparation never saw, and DI's strict check rejects it.

Any wrapper array whose `copy` narrows to `Array` hits this. It surfaces here because comparing against the real-embedded formulation passes `reinterpret(Float64, ::Vector{ComplexF64})` as `initial_x`. This package's compat is `NLSolversBase = "7"`, so it arrived through a compatible dependency upgrade with no change on the NLsolve side.

The fix presumably belongs upstream: seed preparation with the array that will actually be used, `x_f`, so preparation and execution agree by construction. `strict=Val(false)` would silence the check but leaves preparation specialised on a type that never appears at execution.

Only the methods that build a `OnceDifferentiable` are affected. `:anderson` builds a `NonDifferentiable`, prepares no jacobian, and compares fine, so it stays a live `@test`. The complex solves themselves are now asserted directly rather than only relative to the real-embedded run, so that side keeps its coverage. `@test_broken` errors on an unexpected pass, so this reverts to `@test` on its own once the upstream fix lands.

## Result

Suite is green. `complex` reports 15 pass, 6 broken; `singular case` keeps its 2 intentional broken tests. `interface/caches.jl` and `fixedpoint/fixedpoint.jl` run for the first time in a while and pass.

---

This pull request was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
