### PR TITLE
Complete the autoscale underflow fix and add the #297 regression test

### DIFF
--- a/src/solvers/trust_region.jl
+++ b/src/solvers/trust_region.jl
@@ -187,6 +187,9 @@ function trust_region_(df::OnceDifferentiable,
             if autoscale
                 for j = 1:nn
                     cache.d[j] = max(convert(real(T), 0.1) * real(cache.d[j]), norm(view(jacobian(df), :, j)))
+                    if iszero(cache.d[j]^2) # square to catch underflow, as at initialization
+                        cache.d[j] = oneunit(cache.d[j])
+                    end
                 end
             end
 

--- a/test/singular.jl
+++ b/test/singular.jl
@@ -55,3 +55,32 @@ end
 df = OnceDifferentiable(f_let!, g_let!, rand(10), rand(10))
 r = nlsolve(df, rand(10), method = :trust_region)
 end
+
+@testset "underflowing column norms" begin
+# https://github.com/JuliaNLSolvers/NLsolve.jl/issues/297
+# A Jacobian column with entries below sqrt(floatmin) is nonzero, so it passed
+# the d[j] == 0 guard, but d[j]^2 underflows to zero and g ./ d.^2 in dogleg!
+# produced NaN.
+
+function f_tiny!(F, x)
+    F[1] = x[1] - 2
+    F[2] = 1e-200 * (x[2] - 3)
+end
+
+function g_tiny!(J, x)
+    J[1, 1] = 1.0
+    J[1, 2] = 0.0
+    J[2, 1] = 0.0
+    J[2, 2] = 1e-200
+end
+
+df_tiny = OnceDifferentiable(f_tiny!, g_tiny!, zeros(2), zeros(2))
+
+r = nlsolve(df_tiny, zeros(2), method = :trust_region)
+@test converged(r)
+@test !any(isnan, r.zero)
+@test r.zero ≈ [2.0, 3.0]
+
+r = nlsolve(df_tiny, zeros(2), method = :trust_region, autoscale = false)
+@test !any(isnan, r.zero)
+end


### PR DESCRIPTION
Follow-up to #296 (now merged), completing the fix for #297. Rebased onto master; one commit.

- The per-iteration scaling update had the same hole as the initial block: it recomputes `d[j] = max(0.1 d[j], norm(col))` with no guard, so a long run can decay `d[j]` back below `sqrt(floatmin)`, where `d[j]^2` is zero and `dogleg!` divides by it. The same `iszero(d[j]^2)` guard now applies there.
- Adds the regression test from #297's reproducer: a Jacobian column of `1e-200` passes the old `d[j] == 0` guard, `d[j]^2` underflows, and the solver returned `[NaN, NaN]` with `converged=false`. Verified against pre-#296 master:

  | | converged | zero |
  | --- | --- | --- |
  | before #296 | false | `[NaN, NaN]` |
  | #296 + this | true | `[2.0, 3.0]` |

Fixes #297.

---

This pull request was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
