### PR TITLE
Require NLSolversBase 8.0.1, re-enable the real-embedding tests (v5.0.1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NLsolve"
 uuid = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
-version = "5.0.0"
+version = "5.0.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -16,7 +16,7 @@ ADTypes = "1.11"
 Distances = "0.7, 0.8, 0.9, 0.10"
 ForwardDiff = "0.10, 1"
 LineSearches = "7.6.2"
-NLSolversBase = "8"
+NLSolversBase = "8.0.1"
 Reexport = "0.2, 1.0"
 julia = "1.10"
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -9,15 +9,6 @@ end
 
 solver_kwargs = (store_trace = true, extended_trace = true, iterations = 100, m = 10, beta = 0.01)
 
-# Solving the real-embedded problem means passing
-# reinterpret(Float64, ::Vector{ComplexF64}) as initial_x. NLSolversBase seeds
-# DifferentiationInterface's preparation with the array it is handed but
-# evaluates with copy(x), and copy narrows a ReinterpretArray to a plain
-# Vector, so DI's strict check rejects every evaluation with a
-# PreparationMismatchError. This hits the methods that build a
-# OnceDifferentiable; anderson builds a NonDifferentiable, prepares no
-# jacobian, and is unaffected. Marked broken until NLSolversBase prepares
-# against the array it evaluates with.
 function agrees_with_real_embedding(sol, method, linesearch)
     sol_real = nlsolve(f_real!, reinterpret(Float64, [1.0+0.1im, 2+1im]);
                        method = method, linesearch = linesearch, solver_kwargs...)
@@ -37,17 +28,13 @@ for method in [:newton, :trust_region, :anderson] # TODO add broyden
     sol = nlsolve(f!, [1.0+0.1im, 2+1im]; method = method, solver_kwargs...)
     @test converged(sol)
     @test sol.residual_norm < 1e-8
-    if method === :anderson
-        @test agrees_with_real_embedding(sol, method, Static())
-    else
-        @test_broken agrees_with_real_embedding(sol, method, Static())
-    end
+    @test agrees_with_real_embedding(sol, method, Static())
 end
 
 for linesearch in [BackTracking(), StrongWolfe(), HagerZhang(), MoreThuente()] # Static is covered above
     sol = nlsolve(f!, [1.0+0.1im, 2+1im]; method = :newton, linesearch = linesearch, solver_kwargs...)
     @test converged(sol)
     @test sol.residual_norm < 1e-8
-    @test_broken agrees_with_real_embedding(sol, :newton, linesearch)
+    @test agrees_with_real_embedding(sol, :newton, linesearch)
 end
 end


### PR DESCRIPTION
NLSolversBase 8.0.1 fixes JuliaNLSolvers/NLSolversBase.jl#172, so the six `@test_broken` markers in `test/complex.jl` become live `@test`s again, and the stale comment explaining them goes.

Compat moves from `"8"` to `"8.0.1"`: on 8.0.0 the re-enabled assertions genuinely throw, so allowing it would ship failing tests.

Version bumps to 5.0.1. Suite is green locally on Julia 1.10 against NLSolversBase 8.0.1.

---

This pull request was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
